### PR TITLE
Feature #11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed feature by issue.([Issue #11](https://github.com/overdrive1708/MagonoteToolkit/issues/11))
+
 ## [1.0.0] - 2025-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ MagonoteToolkit_vx.x.x.zipをダウンロードしてください｡
 | Empty | SheetNameで設定したシート名の､Cellで設定したセルが､空である場合にNGとします｡ |
 | NotEmpty | SheetNameで設定したシート名の､Cellで設定したセルが､空ではない場合にNGとします｡ |
 
-制約事項：Cellは｢A1:A5｣のような複数セルの指定は対応していません｡
-
 ## 開発環境
 - Microsoft Visual Studio Community 2022
 


### PR DESCRIPTION
## 対応したIssue / Issue addressed

Fix #11

## 対応内容 / Correspondence contents

Excelファイル検査
範囲指定で複数セルとまとめて検査できるようにした｡

## テスト内容 / Test

- 同一テストファイルで検査し､変更前後で結果が同じであることを確認した｡
- D4とD6を別にしたときとD4:D6にしたときで結果が同じであることを確認した｡

## 補足情報 / Additional context

―