### PR TITLE
Bug #66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade .NET8 to .NET10.
 - Changed feature by issue.([Issue #62](https://github.com/overdrive1708/MagonoteToolkit/issues/62))
 
+### Fixed
+
+- Fixed issue.([Issue #66](https://github.com/overdrive1708/MagonoteToolkit/issues/66))
+
 ## [1.2.0] - 2026-04-04
 
 ### Changed

--- a/src/MagonoteToolkit/Models/ApplicationSettings.cs
+++ b/src/MagonoteToolkit/Models/ApplicationSettings.cs
@@ -100,6 +100,11 @@ namespace MagonoteToolkit.Models
                 byte[] decryptedBytes = ProtectedData.Unprotect(encryptedBytes, null, DataProtectionScope.CurrentUser);
                 readSettings.AIOpenAIAPIKey = Encoding.UTF8.GetString(decryptedBytes);
             }
+            else
+            {
+                // ｢AI関連機能:OpenAI APIのAPIキー｣が空の場合は、ダミー値を設定する｡(OpenAI SDKのエラー回避)
+                readSettings.AIOpenAIAPIKey = "dummy_api_key";
+            }
 
             return readSettings;
         }


### PR DESCRIPTION
## 対応したIssue / Issue addressed

Fix #66 

## 対応内容 / Correspondence contents

OpenAI SDKはAPIキーが空の場合に例外が発生してしまうため､設定値取得処理でダミー値を返すようにした｡
(LM StudioでAPIキーが必要ない設定の場合に､値にダミー値が入っていても正しく応答が来ることを確認した｡)

## テスト内容 / Test

設定を空にして､例外がでないこと･認証不要時に翻訳ができることを確認した｡

## 補足情報 / Additional context

―